### PR TITLE
Update vnet-linuxcluster.parameters.json

### DIFF
--- a/templates/cluster-tutorial/vnet-linuxcluster.parameters.json
+++ b/templates/cluster-tutorial/vnet-linuxcluster.parameters.json
@@ -29,10 +29,10 @@
       "certificateThumbprint": {
         "value": ""
       },
-      "sourceVaultvalue": {
+      "sourceVaultValue": {
         "value": ""
       },
-      "certificateUrlvalue": {
+      "certificateUrlValue": {
         "value": ""
       },
       "subnetName": {


### PR DESCRIPTION
The parameter names must be with a capital "V"as per template file. Otherwise you will get the following output:

"The primary certificate parameters names in the parameters file should be specified with'sourceVaultValue','certificateThumbprint','certificateUrlValue',if the secondary certificate parameters are specified in the parameters file, the parameters names should be specified with'secSourceVaultValue','secCertificateThumbprint','secCertificateUrlValue'"