### PR TITLE
Invalid casing in parameters file.

### DIFF
--- a/templates/cluster-tutorial/vnet-cluster.parameters.json
+++ b/templates/cluster-tutorial/vnet-cluster.parameters.json
@@ -29,10 +29,10 @@
     "certificateThumbprint": {
       "value": ""
     },
-    "sourceVaultvalue": {
+    "sourceVaultValue": {
       "value": ""
     },
-    "certificateUrlvalue": {
+    "certificateUrlValue": {
       "value": ""
     },
     "subnetName": {
@@ -59,7 +59,7 @@
     "loadBalancedAppPort2": {
       "value": 443
     },
-    "certificateStorevalue": {
+    "certificateStoreValue": {
       "value": "My"
     },
     "clusterProtectionLevel": {


### PR DESCRIPTION
Some parameters names in the parameters file are not equal to the casing in the template file. This raises problems when running it on azure-cli.