### PR TITLE
Update dockerfile for service-fabric-reliableservices-windowsservercore to consume the base supported WS 2016 image

### DIFF
--- a/docker/service-fabric-reliableservices-windowsservercore/Dockerfile
+++ b/docker/service-fabric-reliableservices-windowsservercore/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2016
 ADD InstallPreReq.ps1 /
 RUN powershell -File C:\InstallPreReq.ps1
-RUN setx PATH "%PATH%;C:\SFFabricBin;C:\SFFabricRuntimeLoad" /M
+RUN setx PATH "%PATH%;C:\sffabricbin;C:\sffabricruntimeload" /M


### PR DESCRIPTION
Update dockerfile for service-fabric-reliableservices-windowsservercore to consume the base supported WS 2016 image