### PR TITLE
Update Deploy-2NodeTypes-3ScaleSets.json

### DIFF
--- a/templates/nodetype-upgrade/Deploy-2NodeTypes-3ScaleSets.json
+++ b/templates/nodetype-upgrade/Deploy-2NodeTypes-3ScaleSets.json
@@ -549,7 +549,8 @@
                                     "publisher": "Microsoft.Azure.ServiceFabric",
                                     "settings": {
                                         "clusterEndpoint": "[reference(parameters('clusterName')).clusterEndpoint]",
-                                        "nodeTypeRef": "[parameters('vmNodeType0Name')]",
+                                        "
+					    ": "[parameters('vmNodeType0Name')]",
                                         "dataPath": "D:\\\\SvcFab",
                                         "durabilityLevel": "Silver",
                                         "enableParallelJobs": true,
@@ -1139,7 +1140,7 @@
                                     "publisher": "Microsoft.Azure.ServiceFabric",
                                     "settings": {
                                         "clusterEndpoint": "[reference(parameters('clusterName')).clusterEndpoint]",
-                                        "nodeTypeRef": "[parameters('vmNodeType2Name')]",
+                                        "nodeTypeRef": "[parameters('vmNodeType0Name')]",
                                         "dataPath": "D:\\\\SvcFab",
                                         "durabilityLevel": "Silver",
                                         "enableParallelJobs": true,


### PR DESCRIPTION
Per issue #31, PR #30 changed this value but it now makes the template incorrect for the guide it was created for here: https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-scale-up-node-type