### PR TITLE
Update CreateDockerPackage script to use mcr.microsoft.com/windows/se…

### DIFF
--- a/docker/service-fabric-reliableservices-windowsservercore/InstallPreReq.ps1
+++ b/docker/service-fabric-reliableservices-windowsservercore/InstallPreReq.ps1
@@ -1,12 +1,12 @@
 ﻿$scriptDirectory = Split-Path -Parent -Path $MyInvocation.MyCommand.Definition
 $containerSetupLogDirectory = Join-Path $scriptDirectory "ContainerSetupLogs"
 
-$dotnetUrl = "https://download.microsoft.com/download/5/6/B/56BFEF92-9045-4414-970C-AB31E0FC07EC/dotnet-runtime-2.0.0-win-x64.exe"
+$dotnetUrl = "https://download.visualstudio.microsoft.com/download/pr/518aafee-1285-4153-a30a-e4eefd538c90/6437d77a67b9c6b8cf0b7b3323004229/dotnet-runtime-3.1.6-win-x64.exe"
 $vcpp11redistUrl = "https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe"
 $vcpp14redistUrl = "https://download.visualstudio.microsoft.com/download/pr/11687625/2cd2dba5748dc95950a5c42c2d2d78e4/VC_redist.x64.exe"
 
 $TempDir = $env:TEMP
-$dotnetPath = Join-Path $TempDir "dotnet-runtime-2.0.0-win-x64.exe"
+$dotnetPath = Join-Path $TempDir "dotnet-runtime-3.1.6-win-x64.exe"
 $vcpp11redistPath = Join-Path $TempDir "vcredist_x64.exe"
 $vcpp14redistPath = Join-Path $TempDir "vc14_redist.x64.exe"
 
@@ -63,7 +63,7 @@ if(Test-Path($dotnetPath))
 {
     Write-Output "$($dotnetPath) file download Time: $(($DownloadEndTime).Subtract($DownloadStartTime).TotalSeconds) secs"
 
-    Write-Output "Installing dotnet 2.0.0..."
+    Write-Output "Installing dotnet 3.1.6..."
 
     Start-Process "$dotnetPath" -ArgumentList "/install /quiet /norestart /log $(Join-Path $containerSetupLogDirectory log.txt)" -Wait
 

--- a/docker/service-fabric-reliableservices-windowsservercore/README.md
+++ b/docker/service-fabric-reliableservices-windowsservercore/README.md
@@ -1,8 +1,5 @@
 # About
 This folder has Dockerfile to create a Windows Server Core image with prerequisites and environment variables setup to run Service Fabric services inside containers.
 
-## Built Images
-[microsoft/service-fabric-reliableservices-windowsservercore](https://hub.docker.com/r/microsoft/service-fabric-reliableservices-windowsservercore/)
-
 ## More details
 For more information, see the [How to containerize your Service Fabric Services](https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-services-inside-containers)

--- a/scripts/CodePackageToDockerPackage/CreateDockerPackage.ps1
+++ b/scripts/CodePackageToDockerPackage/CreateDockerPackage.ps1
@@ -72,9 +72,12 @@ Write-Host "Creating init.bat for docker package"
 New-Item -ItemType file $initScriptPath -Value $initScriptContents -Force | Out-Null
 
 $dockerfilePath = Join-Path $DockerPackageOutputDirectoryPath -ChildPath "Dockerfile"
-$dockerfileContents = "FROM microsoft/service-fabric-reliableservices-windowsservercore:latest
+$dockerfileContents = 'FROM mcr.microsoft.com/windows/servercore:ltsc2019
+ADD https://raw.githubusercontent.com/microsoft/service-fabric-scripts-and-templates/master/docker/service-fabric-reliableservices-windowsservercore/InstallPreReq.ps1 /
+RUN powershell -File C:\InstallPreReq.ps1
+RUN setx PATH "%PATH%;C:\sffabricbin;C:\sffabricruntimeload" /M
 ADD publish/ /
-CMD C:\init.bat"
+CMD C:\init.bat'
 
 Write-Host "Creating Dockerfile"				   
 New-Item -ItemType file $dockerfilePath -Value $dockerfileContents -Force | Out-Null


### PR DESCRIPTION
Moving away from pre built containers from service fabric. The prerequisites and settings are added to generated Docker file for users to build from official windows/servercore images
Update CreateDockerPackage script to use mcr.microsoft.com/windows/servercore:ltsc2019
Update InstallPreReq.ps1 to install latest dotnet core runtime