### PR TITLE
Revert "Correct node type ref"

### DIFF
--- a/templates/nodetype-upgrade-no-outage/Upgrade-1NodeType-2ScaleSets-ManagedDisks.json
+++ b/templates/nodetype-upgrade-no-outage/Upgrade-1NodeType-2ScaleSets-ManagedDisks.json
@@ -833,7 +833,7 @@
                                     "publisher": "Microsoft.Azure.ServiceFabric",
                                     "settings": {
                                         "clusterEndpoint": "[reference(parameters('clusterName')).clusterEndpoint]",
-                                        "nodeTypeRef": "[parameters('vmNodeType1Name')]",
+                                        "nodeTypeRef": "[parameters('vmNodeType0Name')]",
                                         "dataPath": "D:\\\\SvcFab",
                                         "durabilityLevel": "Silver",
                                         "enableParallelJobs": true,
@@ -966,8 +966,8 @@
                 }
             },
             "sku": {
-                "name": "[parameters('vmNodeType0Size')]",
-                "capacity": "[parameters('nt0InstanceCount')]",
+                "name": "[parameters('vmNodeType1Size')]",
+                "capacity": "[parameters('nt1InstanceCount')]",
                 "tier": "Standard"
             },
             "tags": {
@@ -1034,22 +1034,6 @@
                 "nodeTypes": [
                     {
                         "name": "[parameters('vmNodeType0Name')]",
-                        "applicationPorts": {
-                            "endPort": "[parameters('nt0applicationEndPort')]",
-                            "startPort": "[parameters('nt0applicationStartPort')]"
-                        },
-                        "clientConnectionEndpointPort": "[parameters('nt0fabricTcpGatewayPort')]",
-                        "durabilityLevel": "Silver",
-                        "ephemeralPorts": {
-                            "endPort": "[parameters('nt0ephemeralEndPort')]",
-                            "startPort": "[parameters('nt0ephemeralStartPort')]"
-                        },
-                        "httpGatewayEndpointPort": "[parameters('nt0fabricHttpGatewayPort')]",
-                        "isPrimary": true,
-                        "vmInstanceCount": "[parameters('nt0InstanceCount')]"
-                    },
-                    {
-                        "name": "[parameters('vmNodeType1Name')]",
                         "applicationPorts": {
                             "endPort": "[parameters('nt0applicationEndPort')]",
                             "startPort": "[parameters('nt0applicationStartPort')]"


### PR DESCRIPTION
This reverts commit ec3e27d1c09bfd15ac49ac1565f7e3ea345f698e.

This reverts some [recent edits](https://github.com/MicrosoftDocs/azure-docs-pr/pull/124754) to [Upgrade cluster nodes to use Azure managed disks](https://docs.microsoft.com/en-us/azure/service-fabric/upgrade-managed-disks) tutorial. The edits were made per guidance there should only one VMSS mapped to a node type (nodTypeRef). I tested this and [updated the sample](https://github.com/microsoft/service-fabric-scripts-and-templates/pull/37) accordingly, however results in cluster error state (due to the original node type still existing in the Microsoft.ServiceFabric/clusters manifest, and there not being a good way to get rid of it. 

/Cc https://github.com/MicrosoftDocs/azure-docs-pr/pull/125211