### PR TITLE
use certificate Id instead of thumbs in backends

### DIFF
--- a/templates/service-integration/apim.json
+++ b/templates/service-integration/apim.json
@@ -42,10 +42,10 @@
                 "description": "Certificate password to use to talk to Service Fabric Backend."
             }
         },
-        "serviceFabricCertificateThumbprint": {
+        "serviceFabricCertificateId": {
             "type": "string",
             "metadata": {
-                "description": "Certificate Thumbprint to use to talk to Service Fabric Backend."
+                "description": "Certificate Id to use to talk to Service Fabric Backend."
             }
         },
         "clusterHttpManagementEndpoint": {

--- a/templates/service-integration/apim.parameters.json
+++ b/templates/service-integration/apim.parameters.json
@@ -20,8 +20,8 @@
         "certificatePassword": {
             "value": "q6D7nN%6ck@6"
         },
-        "serviceFabricCertificateThumbprint": {
-            "value": ""
+        "serviceFabricCertificateId": {
+            "value": "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.ApiManagement/service/apimService1/certificates/cert1"
         },
         "url_path": {
             "value": "/api/values"
@@ -29,7 +29,7 @@
         "clusterHttpManagementEndpoint": {
             "value": "https://mysfcluster123.southcentralus.cloudapp.azure.com:19080"
         },
-        "inbound_policy":{
+        "inbound_policy": {
             "value": "<policies>\r\n  <inbound>\r\n    <base />\r\n    <set-backend-service backend-id=\"servicefabric\" sf-service-instance-name=\"fabric:/ApiApplication/WebApiService\" sf-resolve-condition=\"@((int)context.Response.StatusCode != 200)\" />\r\n  </inbound>\r\n  <backend>\r\n    <base />\r\n  </backend>\r\n  <outbound>\r\n    <base />\r\n  </outbound>\r\n  <on-error>\r\n    <base />\r\n  </on-error>\r\n</policies>"
         },
         "policies_policy_name": {


### PR DESCRIPTION
for auto-rotation need, we're referencing certificates by Id instead of Thumbprints