### PR TITLE
SF Local Cluster Support for Linux VM (wsl2) when systemd is not running as PID1

### DIFF
--- a/scripts/SetupServiceFabric/SetupServiceFabric.sh
+++ b/scripts/SetupServiceFabric/SetupServiceFabric.sh
@@ -26,6 +26,87 @@ if [[ "xenial" != "$Distribution" && "bionic" != "$Distribution" ]]; then
     exit -1
 fi
 
+# Check if systemd is running as PID1, if not it should enabled via system-genie
+pidone=$(ps --no-headers -o comm 1)
+if [ "systemd"!="$pidone" ]; then
+	# Setting up system-genie to run systemd as PID 1
+    echo "Setting up system-genie to run systemd as PID 1"
+    echo "Installing .NET SDK and runtime 5.0"
+    wget https://packages.microsoft.com/config/ubuntu/21.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+    dpkg -i packages-microsoft-prod.deb
+    rm packages-microsoft-prod.deb
+
+    echo "Installing the .NET SDK"
+    apt-get update; \
+    apt-get install -y apt-transport-https && \
+    apt-get update && \
+    apt-get install -y dotnet-sdk-5.0
+
+    echo "Installing the .NET runtime "
+    apt-get update; \
+    apt-get install -y apt-transport-https && \
+    apt-get update && \
+    apt-get install -y aspnetcore-runtime-5.0
+
+    echo "Adding the wsl-translinux repository"
+    apt install apt-transport-https
+
+    wget -O /etc/apt/trusted.gpg.d/wsl-transdebian.gpg https://arkane-systems.github.io/wsl-transdebian/apt/wsl-transdebian.gpg
+    chmod a+r /etc/apt/trusted.gpg.d/wsl-transdebian.gpg
+
+    file="/etc/apt/sources.list.d/wsl-transdebian.list"
+    echo "deb https://arkane-systems.github.io/wsl-transdebian/apt/ $(lsb_release -cs) main" >> $file
+    echo "deb-src https://arkane-systems.github.io/wsl-transdebian/apt/ $(lsb_release -cs) main" >> $file
+    cat $file
+
+    apt update
+    echo "Installing system-genie"
+    apt install -y systemd-genie
+
+    echo "Starting genie"
+    genie -i
+    echo "Genie has been started"
+
+    sudo -i -u root bash << EOF
+        # sed -i 's/nameserver.*/nameserver 172.17.176.1/' /etc/resolv.conf
+
+        genie -c wget -q https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb
+        genie -c dpkg -i packages-microsoft-prod.deb
+        # genie -c ExitIfError $?  "Error@$LINENO: Failed to add package $MSPackage"
+
+        genie -c curl -fsSL https://packages.microsoft.com/keys/msopentech.asc | sudo apt-key add -
+        # genie -c ExitIfError $?  "Error@$LINENO: Failed to add MS GPG key"
+
+		genie -c curl -fsSL https://download.docker.com/linux/ubauntu/gpg | sudo apt-key add -
+        # genie -c ExitIfError $?  "Error@$LINENO: Failed to add Docker GPG key"
+
+        genie -c add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+        # genie -c ExitIfError $?  "Error@$LINENO: Failed to setup docker repository"
+
+        genie -c apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9
+        genie -c apt-add-repository "deb http://repos.azul.com/azure-only/zulu/apt stable main"
+
+        genie -c apt-get -y update
+
+		echo "Installing servicefabricsdkcommon"
+        genie -c echo "servicefabric servicefabric/accepted-eula-ga select true" | sudo debconf-set-selections
+        genie -c echo "servicefabricsdkcommon servicefabricsdkcommon/accepted-eula-ga select true" | sudo debconf-set-selections
+        genie -c apt-get -y install servicefabricsdkcommon
+        # genie -c ExitIfError $?  "Error@$LINENO: Failed to install Service Fabric SDK"
+
+        # install pyton-pip and sfctl
+        genie -c apt-get -y install python-pip
+		# genie -c ExitIfError $?  "Error@$LINENO: Failed to install python for sfctl setup."
+
+        genie -c pip install sfctl
+		# genie -c ExitIfError $?  "Error@$LINENO: sfctl installation failed."
+
+        #echo "Starting cluster"
+        #genie -c /opt/microsoft/sdk/servicefabric/common/clustersetup/devclustersetup.sh
+EOF
+
+else
+
 #
 # Install all packages
 #
@@ -77,3 +158,5 @@ ExitIfError $?  "Error@$LINENO: sfctl installation failed."
 export PATH=$PATH:$HOME/.local/bin/
 
 echo "Successfully completed Service Fabric SDK installation and setup."
+
+fi

--- a/scripts/SetupServiceFabric/SetupServiceFabric.sh
+++ b/scripts/SetupServiceFabric/SetupServiceFabric.sh
@@ -26,10 +26,10 @@ if [[ "xenial" != "$Distribution" && "bionic" != "$Distribution" ]]; then
     exit -1
 fi
 
-# Check if systemd is running as PID1, if not it should enabled via system-genie
+# Check if systemd is running as PID1, if not it should be enabled via system-genie
 pidone=$(ps --no-headers -o comm 1)
 if [ "systemd" != "$pidone" ]; then
-	# Setting up system-genie to run systemd as PID 1
+    # Set system-genie to run systemd as PID 1
     echo "Setting up system-genie to run systemd as PID 1"
     echo "Installing .NET SDK and runtime 5.0"
     wget https://packages.microsoft.com/config/ubuntu/21.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
@@ -63,10 +63,12 @@ if [ "systemd" != "$pidone" ]; then
     echo "Installing system-genie"
     apt install -y systemd-genie
 
+    # Start genie
     echo "Starting genie"
     genie -i
     echo "Genie has been started"
 
+    # Setup service fabric runtime and sdk inside genie namespace
     sudo -i -u root bash << EOF
         # sed -i 's/nameserver.*/nameserver 172.17.176.1/' /etc/resolv.conf
 
@@ -100,9 +102,6 @@ if [ "systemd" != "$pidone" ]; then
 
         genie -c pip install sfctl
         # genie -c ExitIfError $?  "Error@$LINENO: sfctl installation failed."
-
-        #echo "Starting cluster"
-        #genie -c /opt/microsoft/sdk/servicefabric/common/clustersetup/devclustersetup.sh
 EOF
 
 else

--- a/scripts/SetupServiceFabric/SetupServiceFabric.sh
+++ b/scripts/SetupServiceFabric/SetupServiceFabric.sh
@@ -189,13 +189,13 @@ fi
 # Setup Azure Service Fabric CLI
 #
 
-$genieCommand apt-get install python -f -y
-ExitIfError $?  "Error@$LINENO: Failed to install python for sfctl setup."
+$genieCommand apt-get install python3 -f -y
+ExitIfError $?  "Error@$LINENO: Failed to install python3 for sfctl setup."
 
-$genieCommand apt-get install python-pip -f -y
+$genieCommand apt-get install python3-pip -f -y
 ExitIfError $?  "Error@$LINENO: Failed to install pip for sfctl setup."
 
-$genieCommand pip install sfctl
+$genieCommand pip3 install sfctl
 ExitIfError $?  "Error@$LINENO: sfctl installation failed."
 
 export PATH=$PATH:$HOME/.local/bin/

--- a/scripts/SetupServiceFabric/SetupServiceFabric.sh
+++ b/scripts/SetupServiceFabric/SetupServiceFabric.sh
@@ -164,17 +164,22 @@ echo "servicefabricsdkcommon servicefabricsdkcommon/accepted-eula-ga select true
 #  If local debian packages for ServiceFabricRunTime and ServiceFabricSDK are provided, install SF SDK from these packages
 #
 if [[ ! -z $ServiceFabricRuntimePath ]] && [[ ! -z $ServiceFabricSdkPath ]]; then
-    echo "Copying $ServiceFabricRuntimePath to /opt/servicefabricruntime.deb"
-    cp $ServiceFabricRuntimePath /opt/servicefabricruntime.deb
-    echo "Copying $ServiceFabricSdkPath to /opt/servicefabricsdkcommon.deb"
-    cp $ServiceFabricSdkPath /opt/servicefabricsdkcommon.deb
+    echo "Copying $ServiceFabricRuntimePath to /var/cache/apt/archives/servicefabric.deb"
+    cp $ServiceFabricRuntimePath /var/cache/apt/archives/servicefabric.deb
+    echo "Copying $ServiceFabricSdkPath to /var/cache/apt/archives/servicefabricsdkcommon.deb"
+    cp $ServiceFabricSdkPath /var/cache/apt/archives/servicefabricsdkcommon.deb
 
-    echo "Installing servicefabricsdkcommon from local .deb packages"
-    $genieCommand apt -y install /opt/servicefabricruntime.deb
-    $genieCommand apt -y install /opt/servicefabricsdkcommon.deb
-    echo "Removing /opt/servicefabricruntime.deb and /opt/servicefabricsdkcommon.deb"
-    rm /opt/servicefabricruntime.deb
-    rm /opt/servicefabricsdkcommon.deb
+    echo "Installing servicefabric and servicefabricsdkcommon from local .deb packages"
+    $genieCommand dpkg -i /var/cache/apt/archives/servicefabric.deb
+    # Fix broken dependencies for servicefabric if any.
+    $genieCommand apt-get install -f -y
+    $genieCommand dpkg -i /var/cache/apt/archives/servicefabricsdkcommon.deb
+    # Fix broken dependencies for servicefabricsdkcommon if any.
+    $genieCommand apt-get install -f -y
+
+    echo "Removing /var/cache/apt/archives/servicefabric.deb and /var/cache/apt/archives/servicefabricsdkcommon.deb"
+    rm /var/cache/apt/archives/servicefabric.deb
+    rm /var/cache/apt/archives/servicefabricsdkcommon.deb
 else
     $genieCommand apt-get install servicefabricsdkcommon -f -y
     ExitIfError $?  "Error@$LINENO: Failed to install Service Fabric SDK"

--- a/scripts/SetupServiceFabric/SetupServiceFabric.sh
+++ b/scripts/SetupServiceFabric/SetupServiceFabric.sh
@@ -77,7 +77,7 @@ if [ "systemd"!="$pidone" ]; then
         genie -c curl -fsSL https://packages.microsoft.com/keys/msopentech.asc | sudo apt-key add -
         # genie -c ExitIfError $?  "Error@$LINENO: Failed to add MS GPG key"
 
-		genie -c curl -fsSL https://download.docker.com/linux/ubauntu/gpg | sudo apt-key add -
+        genie -c curl -fsSL https://download.docker.com/linux/ubauntu/gpg | sudo apt-key add -
         # genie -c ExitIfError $?  "Error@$LINENO: Failed to add Docker GPG key"
 
         genie -c add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
@@ -88,7 +88,7 @@ if [ "systemd"!="$pidone" ]; then
 
         genie -c apt-get -y update
 
-		echo "Installing servicefabricsdkcommon"
+        echo "Installing servicefabricsdkcommon"
         genie -c echo "servicefabric servicefabric/accepted-eula-ga select true" | sudo debconf-set-selections
         genie -c echo "servicefabricsdkcommon servicefabricsdkcommon/accepted-eula-ga select true" | sudo debconf-set-selections
         genie -c apt-get -y install servicefabricsdkcommon
@@ -96,10 +96,10 @@ if [ "systemd"!="$pidone" ]; then
 
         # install pyton-pip and sfctl
         genie -c apt-get -y install python-pip
-		# genie -c ExitIfError $?  "Error@$LINENO: Failed to install python for sfctl setup."
+        # genie -c ExitIfError $?  "Error@$LINENO: Failed to install python for sfctl setup."
 
         genie -c pip install sfctl
-		# genie -c ExitIfError $?  "Error@$LINENO: sfctl installation failed."
+        # genie -c ExitIfError $?  "Error@$LINENO: sfctl installation failed."
 
         #echo "Starting cluster"
         #genie -c /opt/microsoft/sdk/servicefabric/common/clustersetup/devclustersetup.sh

--- a/scripts/SetupServiceFabric/SetupServiceFabric.sh
+++ b/scripts/SetupServiceFabric/SetupServiceFabric.sh
@@ -121,10 +121,9 @@ if [[ ! -z "$isGenieInstalled" ]]; then
         userentry="$usr ALL = (ALL) NOPASSWD:ALL"
         sed -i "/${userentry}/d" /tmp/sudoers.new
         sed -i "$ a ${userentry}" /tmp/sudoers.new
-        # check validity of entry using visudo, if
+        # check validity of entry using visudo, if validation is successful, replace /etc/sudoers
         visudo -c -f /tmp/sudoers.new
         if [ "$?" -eq "0" ]; then
-            echo "hello world"
             cp /tmp/sudoers.new /etc/sudoers
         fi
         rm /tmp/sudoers.new

--- a/scripts/SetupServiceFabric/SetupServiceFabric.sh
+++ b/scripts/SetupServiceFabric/SetupServiceFabric.sh
@@ -3,13 +3,14 @@
 #
 # This script installs and sets up the Service Fabric Runtime and Common SDK.
 # It also sets up Azure Service Fabric CLI
-#
+
 # Usage: sudo ./SetupServiceFabric.sh
-# Setting up Service Fabric from local service fabric runtime and sdk debain packages is all supported, both two debain packages will be needed for installation.
-# This script should be called with path of sf runtime and sf sdk. Below is the sample
-# sudo ./setup.sh --servicefabricruntime=/mnt/c/Users/sindoria/Downloads/servicefabric_8.2.142.2.deb --servicefabricsdk=/mnt/c/Users/sindoria/Downloads/servicefabric_sdkcommon_1.4.2.deb
+# Above fetches Service Fabric Runtime and SDK along with required packages/dependencies from repositories and does the setup.
+# This script also supports installation of SDK from local .deb packages of Servie Fabric runtime and sdk. Both packages will be needed for installation and paths should be provided as parameters.
+# Below is the sample:
+# sudo ./SetupServiceFabric.sh --servicefabricruntime=/mnt/c/Users/sindoria/Downloads/servicefabric_8.2.142.2.deb --servicefabricsdk=/mnt/c/Users/sindoria/Downloads/servicefabric_sdkcommon_1.4.2.deb
 # In above scenario sf runtime is located at C:\Users\sindoria\Downloads\servicefabric_8.2.142.2.deb in windows host but in VM it will look like /mnt/c/Users/sindoria/Downloads/servicefabric_8.2.142.2.deb
-# Above paths should be provided appropriately as per Linux VM
+# Above paths should be provided appropriately as per Linux VM.
 #
 
 if [ "$EUID" -ne 0 ]; then

--- a/scripts/SetupServiceFabric/SetupServiceFabric.sh
+++ b/scripts/SetupServiceFabric/SetupServiceFabric.sh
@@ -5,7 +5,7 @@
 # It also sets up Azure Service Fabric CLI
 #
 # Usage: sudo ./SetupServiceFabric.sh
-# Setting up Service Fabric from local .deb packages is supported for WSL2 based Linux VM
+# Setting up Service Fabric from local service fabric runtime and sdk debain packages is all supported, both two debain packages will be needed for installation.
 # This script should be called with path of sf runtime and sf sdk. Below is the sample
 # sudo ./setup.sh --servicefabricruntime=/mnt/c/Users/sindoria/Downloads/servicefabric_8.2.142.2.deb --servicefabricsdk=/mnt/c/Users/sindoria/Downloads/servicefabric_sdkcommon_1.4.2.deb
 # In above scenario sf runtime is located at C:\Users\sindoria\Downloads\servicefabric_8.2.142.2.deb in windows host but in VM it will look like /mnt/c/Users/sindoria/Downloads/servicefabric_8.2.142.2.deb
@@ -100,12 +100,12 @@ genieCommand=''
 isGenieInstalled=$(apt list --installed | grep systemd-genie)
 
 if [[ ! -z "$isGenieInstalled" ]]; then
-	isGenieRunning=$(genie -r)
-	isOutsideGenie=$(genie -b)
+    isGenieRunning=$(genie -r)
+    isOutsideGenie=$(genie -b)
 
-	if [[ "$isGenieRunning"=="runnning" && "$isOutsideGenie"=="outside" ]]; then
-		genieCommand="genie -c"
-	fi
+    if [[ "$isGenieRunning"=="runnning" && "$isOutsideGenie"=="outside" ]]; then
+        genieCommand="genie -c"
+    fi
 fi
 
 #
@@ -131,7 +131,6 @@ ExitIfError $?  "Error@$LINENO: Failed to add key for zulu repo"
 
 apt-get update
 
-
 #
 # Install Service Fabric SDK.
 #
@@ -142,21 +141,20 @@ echo "servicefabricsdkcommon servicefabricsdkcommon/accepted-eula-ga select true
 #  If local debian packages for ServiceFabricRunTime and ServiceFabricSDK are provided, install SF SDK from these packages
 #
 if [[ ! -z $ServiceFabricRuntimePath ]] && [[ ! -z $ServiceFabricSdkPath ]]; then
-	echo "Copying $ServiceFabricRuntimePath to /opt/servicefabricruntime.deb"
-	cp $ServiceFabricRuntimePath /opt/servicefabricruntime.deb
-	echo "Copying $ServiceFabricSdkPath to /opt/servicefabricsdkcommon.deb"
-	cp $ServiceFabricSdkPath /opt/servicefabricsdkcommon.deb
+    echo "Copying $ServiceFabricRuntimePath to /opt/servicefabricruntime.deb"
+    cp $ServiceFabricRuntimePath /opt/servicefabricruntime.deb
+    echo "Copying $ServiceFabricSdkPath to /opt/servicefabricsdkcommon.deb"
+    cp $ServiceFabricSdkPath /opt/servicefabricsdkcommon.deb
 
-	echo "Installing servicefabricsdkcommon from local .deb packages"
-
+    echo "Installing servicefabricsdkcommon from local .deb packages"
     $genieCommand apt -y install /opt/servicefabricruntime.deb
     $genieCommand apt -y install /opt/servicefabricsdkcommon.deb
     echo "Removing /opt/servicefabricruntime.deb and /opt/servicefabricsdkcommon.deb"
     rm /opt/servicefabricruntime.deb
     rm /opt/servicefabricsdkcommon.deb
 else
-	$genieCommand apt-get install servicefabricsdkcommon -f -y
-	ExitIfError $?  "Error@$LINENO: Failed to install Service Fabric SDK"
+    $genieCommand apt-get install servicefabricsdkcommon -f -y
+    ExitIfError $?  "Error@$LINENO: Failed to install Service Fabric SDK"
 fi
 
 #

--- a/scripts/SetupServiceFabric/SetupServiceFabric.sh
+++ b/scripts/SetupServiceFabric/SetupServiceFabric.sh
@@ -28,7 +28,7 @@ fi
 
 # Check if systemd is running as PID1, if not it should enabled via system-genie
 pidone=$(ps --no-headers -o comm 1)
-if [ "systemd"!="$pidone" ]; then
+if [ "systemd" != "$pidone" ]; then
 	# Setting up system-genie to run systemd as PID 1
     echo "Setting up system-genie to run systemd as PID 1"
     echo "Installing .NET SDK and runtime 5.0"


### PR DESCRIPTION
This features enables support for setting up SF Local cluster inside WSL2 based Ubuntu VM. Inside Ubuntu VM systemd is not running as PID1, this script change will enable that via system genie (by creating a separate namespace). Once genie is setup, installation of SF SDK happens inside the genie namespace and everything needs to be done inside genie namespace with respect to SF cluster and its management.