### PR TITLE
Make SFBinaryLoader preload all dlls

### DIFF
--- a/code/SFBinaryLoaderForContainers/SFBinaryLoader.cs
+++ b/code/SFBinaryLoaderForContainers/SFBinaryLoader.cs
@@ -1,4 +1,4 @@
-﻿namespace StatelessContainer
+namespace StatelessContainer
 {
     using System;
     using System.IO;
@@ -17,6 +17,26 @@
         public static void Initialize()
         {
             SFCodePath = Environment.GetEnvironmentVariable(FabricCodePathEnvironmentVariableName, EnvironmentVariableTarget.Process);
+
+            if (!string.IsNullOrEmpty(SFCodePath) && Directory.Exists(SFCodePath))
+            {
+                PreloadAllAssemblies();
+            }
+        }
+
+        private static void PreloadAllAssemblies()
+        {
+            string[] dllFiles = Directory.GetFiles(SFCodePath, "*.dll", SearchOption.TopDirectoryOnly);
+            
+            foreach (string dllPath in dllFiles)
+            {
+                try
+                {
+                    string assemblyName = Path.GetFileNameWithoutExtension(dllPath);
+                    Assembly.LoadFrom(dllPath);
+                }
+                catch { }
+            }
         }
 
         private static Assembly LoadFromFabricCodePath(object sender, ResolveEventArgs args)

--- a/scripts/CodePackageToDockerPackage/CreateDockerPackage.ps1
+++ b/scripts/CodePackageToDockerPackage/CreateDockerPackage.ps1
@@ -81,7 +81,6 @@ $dockerfilePath = Join-Path $DockerPackageOutputDirectoryPath -ChildPath "Docker
 $dockerfileContents = 'FROM mcr.microsoft.com/windows/servercore:ltsc2019
 ADD https://raw.githubusercontent.com/microsoft/service-fabric-scripts-and-templates/master/docker/service-fabric-reliableservices-windowsservercore/InstallPreReq.ps1 /
 RUN powershell -File C:\InstallPreReq.ps1
-RUN setx PATH "%PATH%;C:\sffabricbin;C:\sffabricruntimeload" /M
 ADD publish/ /
 CMD C:\init.bat'
 


### PR DESCRIPTION
Make SFBinaryLoader preload all dlls. This makes it possible to not delete the System.Fabric.*.dll from the root directory, as it will first try to load them from the FabricCodePath.
Also remove unused path modification in Dockerfile. These folders no longer exist in the container image in the first place.